### PR TITLE
Fixes Minor Point Increase Grammar Issue

### DIFF
--- a/Website/bp_game_management.py
+++ b/Website/bp_game_management.py
@@ -228,7 +228,7 @@ def module_information(moduleid):
         if check_password_hash(module_info.Code, form.passcode.data):
             current_user.current_score = current_user.current_score + module_info.score
             msg = "Success! You entered the correct code! You gained " + str(
-                module_info.score) + " points. You now have " + str(current_user.current_score) + " points"
+                module_info.score) + " points. You now have " + str(current_user.current_score) + " points."
             # flash("Success! You entered the correct code!.")
             flash(msg)
             db.session.commit()

--- a/Website/bp_game_management.py
+++ b/Website/bp_game_management.py
@@ -227,7 +227,7 @@ def module_information(moduleid):
     if form.validate_on_submit():
         if check_password_hash(module_info.Code, form.passcode.data):
             current_user.current_score = current_user.current_score + module_info.score
-            msg = "Success! You entered the correct code!. You gained" + str(
+            msg = "Success! You entered the correct code! You gained " + str(
                 module_info.score) + " points. You now have " + str(current_user.current_score) + " points"
             # flash("Success! You entered the correct code!.")
             flash(msg)


### PR DESCRIPTION
[![grammarscreenshottest.png](https://i.postimg.cc/ZRGc6zW0/grammarscreenshottest.png)](https://postimg.cc/phBzt7Yt)
This is not correct. This pull request alters this text to remove the full stop after the exclamation mark, adds a space between "gained" and the points awarded, and adds a final full stop at the end of the message.