### PR TITLE
Adds a Link to Our Issue Tracker to the Website Home Page

### DIFF
--- a/Website/templates/index.html
+++ b/Website/templates/index.html
@@ -19,6 +19,7 @@
                 <p> Logged in as: {{ user.username }}</p>
             {% endif %}
             <p>Welcome to the Attack of The Kiwis claiming website.</p>
+            <p>Please report any bugs you encounter at <a href="https://github.com/Lake-Tuggeranong-College/CyberRange2022/issues">this page.</a></p>
             <p>List of Departments</p>
 {#            <div class="grid-container">#}
 {#                <div class="alert alert-primary"><a href="192.168.1.101">Traffic Lights</a></div>#}


### PR DESCRIPTION
In this PR, I add a link to our issues page to the home page of the website. We should make use of the tools provided to us by Github, this could help us get specific and more easily accessible end-user feedback. In theory. It works on other repositories I use, sometimes. Could also in theory be used for feature requests but that's controversial. Phrasing could be better like instead of just reporting bugs they could report difficulties they might have, but I'm not sure what words to use in that case. It could be the more general "Report issues you encounter"? I dunno I feel even if we just use "bugs" SOMEONE will report being confused as a bug in the code. Pl*yers are like that.

Looks like this:
[![Home-Pgae-Link.png](https://i.postimg.cc/MpmW562q/Home-Pgae-Link.png)](https://postimg.cc/4YnkNTxS)